### PR TITLE
Add note: Use AI to build the deterministic tool, not to be the tool

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -48,7 +48,7 @@
           CTO at
           <a href="https://www.studiometa.fr/en/" target="_blank" rel="noopener">Studio Meta</a>
           and
-          <a href="https://www.ikko.fr/" target="_blank" rel="noopener">Ikko</a>
+          <a href="https://www.ikko.fr/" target="_blank" rel="noopener">ikko</a>
         </p>
       </div>
       <transition enter-from-class="opacity-0" leave-to-class="opacity-0">
@@ -66,7 +66,7 @@
         Hi 👋, I am the CTO at
         <a href="https://www.studiometa.fr/en/" target="_blank" rel="noopener">Studio Meta</a>
         and
-        <a href="https://www.ikko.fr/" target="_blank" rel="noopener">Ikko</a>
+        <a href="https://www.ikko.fr/" target="_blank" rel="noopener">ikko</a>
         in Strasbourg, France.
         <br />
         <br />

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -1,35 +1,35 @@
 ---
-title: Use AI to build the deterministic tool, not to be the tool
-description: Why a deterministic program often beats handing a workflow to an agent, with numbers from a code reviewer.
+title: Use AI to build deterministic tools, not to run repetitive workflows
+description: A code-review experiment comparing deterministic context staging with agent-led context discovery.
 tags: ai, agents, determinism
 ---
 
-# Use AI to build the deterministic tool, not to be the tool
+# Use AI to build deterministic tools, not to run repetitive workflows
 
 <MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
 
-Sunil Pai's [*one document, two hands*](https://sunilpai.dev/posts/one-document-two-hands/) puts clean words on a rule I keep coming back to: the model handles the fuzzy intent, and deterministic code handles the precise work.
+Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/) describes a rule I use: models handle ambiguous intent; deterministic code handles defined steps.
 
-The practical version is simple: when a workflow gets repetitive and needs deterministic output, an agent is rarely the right tool. Use the model to write a deterministic program, then keep the agent out of the runtime as much as possible. You pay for the model once to build the tool, and after that it is ordinary code: predictable, testable, and cheap to run.
+When a repetitive workflow requires consistent output, use a model to write a program instead of running an agent each time. The resulting code is predictable, testable, and cheap to run.
 
 ## Why not an agent
 
-A non-deterministic agent has two recurring costs. It spends tokens, because it re-derives the context and re-plans on every run. And it is hard to reason about, because what it does today is not necessarily what it does tomorrow. Most of a workflow is not fuzzy anyway: staging files, filtering noise, pulling repository context and shaping a prompt are deterministic steps that a script handles for free. The useful question is not which agent should run a task, but which parts of it are deterministic and whether the model can write that code.
+An agent reconstructs context and plans on every run, consuming tokens and potentially producing different results. Most of the workflow may not require judgment: staging files, filtering noise, collecting repository context, and shaping a prompt are deterministic steps. Put those steps in code and reserve the model for the parts that require interpretation.
 
 ## A measured example
 
-Our code reviewer [`@weareikko/code-review`](https://github.com/weareikko/code-review) gathers context deterministically. It stages the files that are not noise, pulls repository and PR context, and configures the relevant skills, and then the model reviews. We tried letting the agent discover its own context by giving it the right tools, thinking this was the most efficient way for it to review a diff, but the measurements told us the opposite.
+Our code reviewer [`@weareikko/code-review`](https://github.com/weareikko/code-review) filters and stages files, collects repository and pull request context, and configures the relevant skills before the model reviews the diff. We compared this pipeline with an agent that discovered its own context through read-only Git tools.
 
-A [controlled test](https://github.com/weareikko/code-review/pull/131) used synthetic diffs with bugs planted at known locations, so recall was measurable. The clearest case was a 269k diff, 2.7 times the budget, with the bugs in the small files that get dropped first.
+A [controlled test](https://github.com/weareikko/code-review/pull/131) used synthetic diffs with bugs at known locations, making recall measurable. One fixture was about 269,000 characters—2.7 times the 100,000-character inline budget—with bugs in small files that inline mode dropped first.
 
-| mode | recall | cost |
-|---|---|---|
-| inline (diff in the prompt) | 80–83% | ~$0.09 |
-| disk (files staged, read on demand) | 100% | variable |
-| commits (agent explores via git tools) | 100% | ~$0.19–0.24 |
+| mode                                   | recall | cost        |
+| -------------------------------------- | ------ | ----------- |
+| inline (diff in the prompt)            | 80–83% | ~$0.09      |
+| disk (files staged, read on demand)    | 100%   | variable    |
+| commits (agent explores via git tools) | 100%   | ~$0.19–0.24 |
 
-The mode where the agent finds context on its own is commits, which explores history through read-only git tools. It reached the same recall as deterministic staging, and it was the most expensive way to do so, roughly two to three times the inline cost, mostly from `git_show` token bloat. The extra autonomy did not surface better bugs. One caveat: the staging cost varies a lot between runs, and the bugs were synthetic, so the result reads as a direction rather than a benchmark.
+`commits`, in which the agent explores history through read-only Git tools, matched `disk` mode's 100% recall. It cost $0.19–$0.24, compared with about $0.09 for `inline`, largely because of `git_show` output, without improving recall over `disk`. Because the bugs were synthetic and `disk` costs varied substantially, treat this as directional evidence rather than a benchmark.
 
 ## When an agent is worth it
 
-None of this argues against agents. The freedom is worth its cost when the task is genuinely open, such as interpreting a vague request or weighing two designs. It is a poor trade when the task is mechanical but framed as reasoning. The pattern to watch for is reaching for an agent because a step is repetitive, when repetitive is usually a sign that the step should be code.
+Agents remain useful for open-ended tasks such as interpreting vague requests or comparing designs. For repetitive mechanical tasks, write code instead.

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -1,0 +1,35 @@
+---
+title: Use AI to build the deterministic tool, not to be the tool
+description: Why a deterministic program often beats handing a workflow to an agent, with numbers from a code reviewer.
+tags: ai, agents, determinism
+---
+
+# Use AI to build the deterministic tool, not to be the tool
+
+<MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
+
+Sunil Pai's [*one document, two hands*](https://sunilpai.dev/posts/one-document-two-hands/) puts clean words on a rule I keep coming back to: the model handles the fuzzy intent, and deterministic code handles the precise work.
+
+The practical version is simple. When a workflow gets repetitive, an agent is rarely the right tool. Use the model to write a deterministic program, then keep the agent out of the runtime as much as possible. You pay for the model once, when the tool is built, and after that it is ordinary code: predictable, testable, and cheap to run.
+
+## Why not an agent
+
+A non-deterministic agent has two recurring costs. It spends tokens, because it re-derives the context and re-plans on every run. And it is hard to reason about, because what it does today is not necessarily what it does tomorrow. Most of a workflow is not fuzzy anyway. Staging files, filtering noise, pulling repository context and shaping a prompt are deterministic steps that a script handles for free. The useful question is not which agent should run a task, but which parts of it are deterministic and whether the model can write that code.
+
+## A measured example
+
+Our code reviewer, `@weareikko/code-review`, gathers context deterministically. It stages the files that are not noise, pulls repository context, and configures the relevant skills, and then the model reviews. That was not the first design. Letting the agent discover its own context is the more natural one, and it is where the project started. The measurements changed that.
+
+A [controlled test](https://github.com/weareikko/code-review/pull/131) used synthetic diffs with bugs planted at known locations, so recall was measurable. The clearest case was a 269k diff, 2.7 times the budget, with the bugs in the small files that get dropped first.
+
+| mode | recall | cost |
+|---|---|---|
+| inline (diff in the prompt) | 80–83% | ~$0.09 |
+| disk (files staged, read on demand) | 100% | variable |
+| commits (agent explores via git tools) | 100% | ~$0.19–0.24 |
+
+The mode where the agent finds context on its own is commits, which explores history through read-only git tools. It reached the same recall as deterministic staging, and it was the most expensive way to do so, roughly two to three times the inline cost, mostly from `git_show` token bloat. The extra autonomy did not surface better bugs. One caveat: the staging cost varies a lot between runs, and the bugs were synthetic, so the result reads as a direction rather than a benchmark.
+
+## When an agent is worth it
+
+None of this argues against agents. The freedom is worth its cost when the task is genuinely open, such as interpreting a vague request or weighing two designs. It is a poor trade when the task is mechanical but framed as reasoning. The pattern to watch for is reaching for an agent because a step is repetitive, when repetitive is usually a sign that the step should be code.

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -8,7 +8,7 @@ tags: ai, agents, determinism
 
 <MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
 
-Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/) describes a rule I use: models handle ambiguous intent; deterministic code handles defined steps.
+Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/) describes a rule I use and share with the team at [Ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
 
 When a repetitive workflow requires consistent output, use a model to write a program instead of running an agent each time. The resulting code is predictable, testable, and cheap to run.
 

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -10,15 +10,15 @@ tags: ai, agents, determinism
 
 Sunil Pai's [*one document, two hands*](https://sunilpai.dev/posts/one-document-two-hands/) puts clean words on a rule I keep coming back to: the model handles the fuzzy intent, and deterministic code handles the precise work.
 
-The practical version is simple. When a workflow gets repetitive, an agent is rarely the right tool. Use the model to write a deterministic program, then keep the agent out of the runtime as much as possible. You pay for the model once, when the tool is built, and after that it is ordinary code: predictable, testable, and cheap to run.
+The practical version is simple: when a workflow gets repetitive and needs deterministic output, an agent is rarely the right tool. Use the model to write a deterministic program, then keep the agent out of the runtime as much as possible. You pay for the model once to build the tool, and after that it is ordinary code: predictable, testable, and cheap to run.
 
 ## Why not an agent
 
-A non-deterministic agent has two recurring costs. It spends tokens, because it re-derives the context and re-plans on every run. And it is hard to reason about, because what it does today is not necessarily what it does tomorrow. Most of a workflow is not fuzzy anyway. Staging files, filtering noise, pulling repository context and shaping a prompt are deterministic steps that a script handles for free. The useful question is not which agent should run a task, but which parts of it are deterministic and whether the model can write that code.
+A non-deterministic agent has two recurring costs. It spends tokens, because it re-derives the context and re-plans on every run. And it is hard to reason about, because what it does today is not necessarily what it does tomorrow. Most of a workflow is not fuzzy anyway: staging files, filtering noise, pulling repository context and shaping a prompt are deterministic steps that a script handles for free. The useful question is not which agent should run a task, but which parts of it are deterministic and whether the model can write that code.
 
 ## A measured example
 
-Our code reviewer, `@weareikko/code-review`, gathers context deterministically. It stages the files that are not noise, pulls repository context, and configures the relevant skills, and then the model reviews. That was not the first design. Letting the agent discover its own context is the more natural one, and it is where the project started. The measurements changed that.
+Our code reviewer [`@weareikko/code-review`](https://github.com/weareikko/code-review) gathers context deterministically. It stages the files that are not noise, pulls repository and PR context, and configures the relevant skills, and then the model reviews. We tried letting the agent discover its own context by giving it the right tools, thinking this was the most efficient way for it to review a diff, but the measurements told us the opposite.
 
 A [controlled test](https://github.com/weareikko/code-review/pull/131) used synthetic diffs with bugs planted at known locations, so recall was measurable. The clearest case was a 269k diff, 2.7 times the budget, with the bugs in the small files that get dropped first.
 

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -8,7 +8,7 @@ tags: ai, agents, determinism
 
 <MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
 
-Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/#let-boring-code-do-the-precise-bits) describes a rule I use and share with the team at [ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
+Sunil Pai's [one document, two hands](https://sunilpai.dev/posts/one-document-two-hands/#let-boring-code-do-the-precise-bits) describes a rule I use and share with the team at [ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
 
 When a repetitive workflow requires consistent output, use a model to write a program instead of running an agent each time. The resulting code is predictable, testable, and cheap to run.
 

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -8,7 +8,7 @@ tags: ai, agents, determinism
 
 <MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
 
-Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/) describes a rule I use and share with the team at [Ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
+Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/) describes a rule I use and share with the team at [ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
 
 When a repetitive workflow requires consistent output, use a model to write a program instead of running an agent each time. The resulting code is predictable, testable, and cheap to run.
 

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -1,10 +1,10 @@
 ---
-title: Use AI to build deterministic tools, not to run repetitive workflows
+title: Use AI to build deterministic tools
 description: A code-review experiment comparing deterministic context staging with agent-led context discovery.
 tags: ai, agents, determinism
 ---
 
-# Use AI to build deterministic tools, not to run repetitive workflows
+# Use AI to build deterministic tools
 
 <MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
 

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -18,17 +18,33 @@ An agent reconstructs context and plans on every run, consuming tokens and poten
 
 ## A measured example
 
-Our code reviewer [`@weareikko/code-review`](https://github.com/weareikko/code-review) filters and stages files, collects repository and pull request context, and configures the relevant skills before the model reviews the diff. We compared this pipeline with an agent that discovered its own context through read-only Git tools.
+Our code reviewer [`@weareikko/code-review`](https://github.com/weareikko/code-review) filters and stages files, collects repository and pull request context, and configures the relevant skills before the model reviews the diff. We arrived at this design after comparing deterministic prompt construction with an agent that discovered its own context through read-only Git tools.
 
 A [controlled test](https://github.com/weareikko/code-review/pull/131) used synthetic diffs with bugs at known locations, making recall measurable. One fixture was about 269,000 characters—2.7 times the 100,000-character inline budget—with bugs in small files that inline mode dropped first.
 
-| mode                                   | recall | cost        |
-| -------------------------------------- | ------ | ----------- |
-| inline (diff in the prompt)            | 80–83% | ~$0.09      |
-| disk (files staged, read on demand)    | 100%   | variable    |
-| commits (agent explores via git tools) | 100%   | ~$0.19–0.24 |
+<table class="w-full">
+  <thead>
+    <tr>
+      <th class="border-b border-current py-2 pr-4 text-left">mode</th>
+      <th class="whitespace-nowrap border-b border-current px-4 py-2 text-left">recall</th>
+      <th class="whitespace-nowrap border-b border-current py-2 pl-4 text-left">cost</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="py-2 pr-4"><code>inline</code> (diff in the prompt)</td>
+      <td class="whitespace-nowrap px-4 py-2">80–83%</td>
+      <td class="whitespace-nowrap py-2 pl-4">~$0.09</td>
+    </tr>
+    <tr>
+      <td class="py-2 pr-4"><code>commits</code> (agent explores with Git tools)</td>
+      <td class="whitespace-nowrap px-4 py-2">100%</td>
+      <td class="whitespace-nowrap py-2 pl-4">~$0.19–0.24</td>
+    </tr>
+  </tbody>
+</table>
 
-`commits`, in which the agent explores history through read-only Git tools, matched `disk` mode's 100% recall. It cost $0.19–$0.24, compared with about $0.09 for `inline`, largely because of `git_show` output, without improving recall over `disk`. Because the bugs were synthetic and `disk` costs varied substantially, treat this as directional evidence rather than a benchmark.
+`commits` recovered every planted bug but cost two to three times as much as `inline`, largely because of `git_show` output. Deterministic disk staging also reached 100% recall without asking the agent to find its own context. Its cost varied substantially, so this does not show that staging is always cheaper. The bugs were also synthetic; treat the result as directional evidence that autonomy did not improve recall over deterministic staging, not as a benchmark.
 
 ## When an agent is worth it
 

--- a/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
+++ b/src/pages/notes/2026/07/21/use-ai-to-build-the-deterministic-tool.md
@@ -8,7 +8,7 @@ tags: ai, agents, determinism
 
 <MetaInfo class="block">21/07/2026 in #ai #agents #determinism</MetaInfo>
 
-Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/) describes a rule I use and share with the team at [ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
+Sunil Pai's [_one document, two hands_](https://sunilpai.dev/posts/one-document-two-hands/#let-boring-code-do-the-precise-bits) describes a rule I use and share with the team at [ikko](https://ikko.fr): models handle ambiguous intent; deterministic code handles defined steps.
 
 When a repetitive workflow requires consistent output, use a model to write a program instead of running an agent each time. The resulting code is predictable, testable, and cheap to run.
 

--- a/src/site.ts
+++ b/src/site.ts
@@ -1,4 +1,4 @@
-const defaultTitle = 'Titouan Mathis · Developer & CTO at Studio Meta & Ikko';
+const defaultTitle = 'Titouan Mathis · Developer & CTO at Studio Meta & ikko';
 
 export default {
   makeTitle: (title) => (title ? `${title} · Titouan Mathis` : defaultTitle),


### PR DESCRIPTION
New note for the Notes section, published at `/notes/2026/07/21/use-ai-to-build-the-deterministic-tool`.

## What

A short, detached-voice note arguing to use the model to write deterministic programs rather than hand repetitive workflows to non-deterministic agents.

- Opens on Sunil Pai's [*one document, two hands*](https://sunilpai.dev/posts/one-document-two-hands/) as the trigger.
- Backs the claim with one measured case from `@weareikko/code-review` ([PR #131](https://github.com/weareikko/code-review/pull/131)): giving the agent read-only git tools to discover context itself matched deterministic staging on recall but cost 2–3× more.
- Keeps the honest caveat (high-variance cost, synthetic bugs, directional not benchmark).

## Notes

- Format matches existing notes (`.md`, `MetaInfo`, no ToC); index is auto-listed via `useListing('notes')`.
- Tone: plain and descriptive, minimal first-person, no em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)